### PR TITLE
Release 0.0.10

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ src
 test-results
 tests
 scripts
+CODEOWNERS
 
 playwright.config.ts
 tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.10]
+
+- [#10](https://github.com/playwright-community/playwright-msteams-reporter/issues/10): Update to the `linkToResultsUrl` and `linkUrlOnFailure` options to support a function that returns the URL
+
 ## [0.0.9]
 
 - [#7](https://github.com/playwright-community/playwright-msteams-reporter/issues/7): Fix for Power Automate webhook URL validation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @estruyf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playwright-msteams-reporter",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playwright-msteams-reporter",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-msteams-reporter",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Microsoft Teams reporter for Playwright which allows you to send notifications about the status of your E2E tests.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,9 @@ export interface MsTeamsReporterOptions {
   webhookUrl?: string;
   webhookType?: WebhookType;
   title?: string;
-  linkToResultsUrl?: string;
+  linkToResultsUrl?: string | (() => string);
   linkToResultsText?: string;
-  linkUrlOnFailure?: string;
+  linkUrlOnFailure?: string | (() => string);
   linkTextOnFailure?: string;
   notifyOnSuccess?: boolean;
   mentionOnFailure?: string;

--- a/src/processResults.test.ts
+++ b/src/processResults.test.ts
@@ -345,6 +345,58 @@ describe("processResults", () => {
     consoleLogSpy.mockReset();
   });
 
+  it("should not include the link from the function when not a string (number)", async () => {
+    const fakeLink = 123;
+    const consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => {
+        if (message.includes("message") && !message.includes(fakeLink)) {
+          console.log(`Did not include ${fakeLink}`);
+        }
+      });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => "1" });
+    global.fetch = fetchMock;
+    const options: MsTeamsReporterOptions = {
+      ...DEFAULT_OPTIONS,
+      webhookUrl: FLOW_WEBHOOK_URL,
+      webhookType: "powerautomate",
+      linkToResultsUrl: (): any => fakeLink,
+      debug: true,
+    };
+    await processResults(SUITE_MOCK_FAILED as any, options);
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Did not include ${fakeLink}`);
+
+    consoleLogSpy.mockReset();
+  });
+
+  it("should not include the link from the function when not a string (undefined)", async () => {
+    const fakeLink = undefined;
+    const consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => {
+        if (message.includes("message") && !message.includes(fakeLink)) {
+          console.log(`Did not include ${fakeLink}`);
+        }
+      });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => "1" });
+    global.fetch = fetchMock;
+    const options: MsTeamsReporterOptions = {
+      ...DEFAULT_OPTIONS,
+      webhookUrl: FLOW_WEBHOOK_URL,
+      webhookType: "powerautomate",
+      linkToResultsUrl: (): any => fakeLink,
+      debug: true,
+    };
+    await processResults(SUITE_MOCK_FAILED as any, options);
+    expect(consoleLogSpy).toHaveBeenCalledWith(`Did not include ${fakeLink}`);
+
+    consoleLogSpy.mockReset();
+  });
+
   it("should include the failure link", async () => {
     const fakeFailureLink =
       "https://github.com/estruyf/playwright-msteams-reporter";
@@ -407,6 +459,74 @@ describe("processResults", () => {
     };
     await processResults(SUITE_MOCK_FAILED as any, options);
     expect(consoleLogSpy).toHaveBeenCalledWith(fakeFailureText);
+
+    consoleLogSpy.mockReset();
+  });
+
+  it("should not include the failure link from the function when not a string (number)", async () => {
+    const fakeFailureLink = 123;
+    const fakeFailureText = "View the failed tests";
+    const consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => {
+        if (
+          message.includes("message") &&
+          !message.includes(fakeFailureLink) &&
+          !message.includes(fakeFailureText)
+        ) {
+          console.log(`Did not include ${fakeFailureLink}`);
+        }
+      });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => "1" });
+    global.fetch = fetchMock;
+    const options: MsTeamsReporterOptions = {
+      ...DEFAULT_OPTIONS,
+      webhookUrl: FLOW_WEBHOOK_URL,
+      webhookType: "powerautomate",
+      linkUrlOnFailure: (): any => fakeFailureLink,
+      linkTextOnFailure: "View the failed tests",
+      debug: true,
+    };
+    await processResults(SUITE_MOCK_FAILED as any, options);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `Did not include ${fakeFailureLink}`
+    );
+
+    consoleLogSpy.mockReset();
+  });
+
+  it("should not include the failure link from the function when not a string (undefined)", async () => {
+    const fakeFailureLink = undefined;
+    const fakeFailureText = "View the failed tests";
+    const consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => {
+        if (
+          message.includes("message") &&
+          !message.includes(fakeFailureLink) &&
+          !message.includes(fakeFailureText)
+        ) {
+          console.log(`Did not include ${fakeFailureLink}`);
+        }
+      });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => "1" });
+    global.fetch = fetchMock;
+    const options: MsTeamsReporterOptions = {
+      ...DEFAULT_OPTIONS,
+      webhookUrl: FLOW_WEBHOOK_URL,
+      webhookType: "powerautomate",
+      linkUrlOnFailure: (): any => fakeFailureLink,
+      linkTextOnFailure: "View the failed tests",
+      debug: true,
+    };
+    await processResults(SUITE_MOCK_FAILED as any, options);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `Did not include ${fakeFailureLink}`
+    );
 
     consoleLogSpy.mockReset();
   });

--- a/src/processResults.test.ts
+++ b/src/processResults.test.ts
@@ -319,6 +319,32 @@ describe("processResults", () => {
     consoleLogSpy.mockReset();
   });
 
+  it("should include the link from the function", async () => {
+    const fakeLink = "https://github.com/estruyf/playwright-msteams-reporter";
+    const consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => {
+        if (message.includes("message") && message.includes(fakeLink)) {
+          console.log(fakeLink);
+        }
+      });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => "1" });
+    global.fetch = fetchMock;
+    const options: MsTeamsReporterOptions = {
+      ...DEFAULT_OPTIONS,
+      webhookUrl: FLOW_WEBHOOK_URL,
+      webhookType: "powerautomate",
+      linkToResultsUrl: () => fakeLink,
+      debug: true,
+    };
+    await processResults(SUITE_MOCK_FAILED as any, options);
+    expect(consoleLogSpy).toHaveBeenCalledWith(fakeLink);
+
+    consoleLogSpy.mockReset();
+  });
+
   it("should include the failure link", async () => {
     const fakeFailureLink =
       "https://github.com/estruyf/playwright-msteams-reporter";
@@ -343,6 +369,39 @@ describe("processResults", () => {
       webhookUrl: FLOW_WEBHOOK_URL,
       webhookType: "powerautomate",
       linkUrlOnFailure: fakeFailureLink,
+      linkTextOnFailure: "View the failed tests",
+      debug: true,
+    };
+    await processResults(SUITE_MOCK_FAILED as any, options);
+    expect(consoleLogSpy).toHaveBeenCalledWith(fakeFailureText);
+
+    consoleLogSpy.mockReset();
+  });
+
+  it("should include the failure link from the function", async () => {
+    const fakeFailureLink =
+      "https://github.com/estruyf/playwright-msteams-reporter";
+    const fakeFailureText = "View the failed tests";
+    const consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((message) => {
+        if (
+          message.includes("message") &&
+          message.includes(fakeFailureLink) &&
+          message.includes(fakeFailureText)
+        ) {
+          console.log(fakeFailureText);
+        }
+      });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, text: () => "1" });
+    global.fetch = fetchMock;
+    const options: MsTeamsReporterOptions = {
+      ...DEFAULT_OPTIONS,
+      webhookUrl: FLOW_WEBHOOK_URL,
+      webhookType: "powerautomate",
+      linkUrlOnFailure: () => fakeFailureLink,
       linkTextOnFailure: "View the failed tests",
       debug: true,
     };

--- a/src/processResults.ts
+++ b/src/processResults.ts
@@ -146,11 +146,13 @@ export const processResults = async (
       linkToResultsUrl = options.linkToResultsUrl();
     }
 
-    adaptiveCard.actions.push({
-      type: "Action.OpenUrl",
-      title: options.linkToResultsText,
-      url: linkToResultsUrl,
-    });
+    if (linkToResultsUrl && typeof linkToResultsUrl === "string") {
+      adaptiveCard.actions.push({
+        type: "Action.OpenUrl",
+        title: options.linkToResultsText,
+        url: linkToResultsUrl,
+      });
+    }
   }
 
   if (!isSuccess && options.linkTextOnFailure && options.linkUrlOnFailure) {
@@ -161,11 +163,13 @@ export const processResults = async (
       linkUrlOnFailure = options.linkUrlOnFailure();
     }
 
-    adaptiveCard.actions.push({
-      type: "Action.OpenUrl",
-      title: options.linkTextOnFailure,
-      url: linkUrlOnFailure,
-    });
+    if (linkUrlOnFailure && typeof linkUrlOnFailure === "string") {
+      adaptiveCard.actions.push({
+        type: "Action.OpenUrl",
+        title: options.linkTextOnFailure,
+        url: linkUrlOnFailure,
+      });
+    }
   }
 
   if (options.webhookType === "powerautomate") {

--- a/src/processResults.ts
+++ b/src/processResults.ts
@@ -139,18 +139,32 @@ export const processResults = async (
 
   // Get the github actions run URL
   if (options.linkToResultsUrl) {
+    let linkToResultsUrl: string;
+    if (typeof options.linkToResultsUrl === "string") {
+      linkToResultsUrl = options.linkToResultsUrl;
+    } else {
+      linkToResultsUrl = options.linkToResultsUrl();
+    }
+
     adaptiveCard.actions.push({
       type: "Action.OpenUrl",
       title: options.linkToResultsText,
-      url: options.linkToResultsUrl,
+      url: linkToResultsUrl,
     });
   }
 
   if (!isSuccess && options.linkTextOnFailure && options.linkUrlOnFailure) {
+    let linkUrlOnFailure: string;
+    if (typeof options.linkUrlOnFailure === "string") {
+      linkUrlOnFailure = options.linkUrlOnFailure;
+    } else {
+      linkUrlOnFailure = options.linkUrlOnFailure();
+    }
+
     adaptiveCard.actions.push({
       type: "Action.OpenUrl",
       title: options.linkTextOnFailure,
-      url: options.linkUrlOnFailure,
+      url: linkUrlOnFailure,
     });
   }
 


### PR DESCRIPTION
- [#10](https://github.com/playwright-community/playwright-msteams-reporter/issues/10): Update to the `linkToResultsUrl` and `linkUrlOnFailure` options to support a function that returns the URL